### PR TITLE
Add mobile-first base template and bubbly styling

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,0 +1,91 @@
+:root {
+  --color-primary: #ff6b6b;
+  --color-secondary: #4ecdc4;
+  --color-bg: #f7f9fc;
+  --color-text: #333;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Quicksand', sans-serif;
+  background: var(--color-bg);
+  color: var(--color-text);
+  line-height: 1.6;
+}
+
+.site-header {
+  background: linear-gradient(135deg, var(--color-primary), var(--color-secondary));
+  padding: 1rem;
+  text-align: center;
+  color: #fff;
+  border-bottom-left-radius: 1.5rem;
+  border-bottom-right-radius: 1.5rem;
+}
+
+.logo {
+  margin: 0;
+  font-weight: 600;
+}
+
+.container {
+  width: 100%;
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+h1.page-title {
+  color: var(--color-primary);
+  margin-top: 0;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+input, select, textarea {
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--color-secondary);
+  border-radius: 1rem;
+  font-size: 1rem;
+}
+
+.btn {
+  background: var(--color-primary);
+  color: #fff;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  border-radius: 1.5rem;
+  cursor: pointer;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: transform 0.2s, background 0.2s;
+  text-decoration: none;
+  text-align: center;
+  display: inline-block;
+}
+
+.error {
+  background: #ffe3e3;
+  color: #c0392b;
+  padding: 1rem;
+  border-radius: 1rem;
+}
+
+.btn:hover,
+.btn:focus {
+  background: var(--color-secondary);
+  transform: translateY(-2px);
+}
+
+@media (min-width: 768px) {
+  .container {
+    max-width: 700px;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,19 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}Mem Vault{% endblock %}</title>
+  <link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="{% static 'css/style.css' %}">
+</head>
+<body>
+  <header class="site-header">
+    <h1 class="logo">Mem Vault</h1>
+  </header>
+  <main class="container">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/app/templates/users/home.html
+++ b/app/templates/users/home.html
@@ -1,8 +1,7 @@
-<!DOCTYPE html>
-<html>
-<body>
-  <h1>Home</h1>
+{% extends 'base.html' %}
+{% block title %}Home - Mem Vault{% endblock %}
+{% block content %}
+  <h1 class="page-title">Home</h1>
   <p>Welcome, {{ request.user.username }}!</p>
-  <a href="{% url 'logout' %}">Logout</a>
-</body>
-</html>
+  <a href="{% url 'logout' %}" class="btn">Logout</a>
+{% endblock %}

--- a/app/templates/users/invitation_invalid.html
+++ b/app/templates/users/invitation_invalid.html
@@ -1,7 +1,6 @@
-<!DOCTYPE html>
-<html>
-<body>
-  <h1>Invalid Invitation</h1>
+{% extends 'base.html' %}
+{% block title %}Invalid Invitation - Mem Vault{% endblock %}
+{% block content %}
+  <h1 class="page-title">Invalid Invitation</h1>
   <p>This invitation link is invalid or has expired.</p>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/users/login.html
+++ b/app/templates/users/login.html
@@ -1,14 +1,13 @@
-<!DOCTYPE html>
-<html>
-<body>
-  <h1>Login</h1>
+{% extends 'base.html' %}
+{% block title %}Login - Mem Vault{% endblock %}
+{% block content %}
+  <h1 class="page-title">Login</h1>
   {% if form.errors %}
-  <p>{{ form.errors }}</p>
+  <div class="error">{{ form.errors }}</div>
   {% endif %}
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Login</button>
+    <button type="submit" class="btn">Login</button>
   </form>
-</body>
-</html>
+{% endblock %}

--- a/app/templates/users/register.html
+++ b/app/templates/users/register.html
@@ -1,11 +1,10 @@
-<!DOCTYPE html>
-<html>
-<body>
-  <h1>Register</h1>
+{% extends 'base.html' %}
+{% block title %}Register - Mem Vault{% endblock %}
+{% block content %}
+  <h1 class="page-title">Register</h1>
   <form method="post">
     {% csrf_token %}
     {{ form.as_p }}
-    <button type="submit">Create Account</button>
+    <button type="submit" class="btn">Create Account</button>
   </form>
-</body>
-</html>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create base.html with responsive meta, font, and linked stylesheet
- add vibrant, rounded CSS for a friendly family vibe
- update user pages to extend base template and use new styles

## Testing
- `python manage.py check`
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_689e3e400238832599957e14b4e2b23f